### PR TITLE
Fix build with SSE4.1 support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -148,6 +148,7 @@ fn build_libwebp() {
         .file("c_src/src/dsp/ssim.c")
         .file("c_src/src/dsp/alpha_processing_sse41.c")
         .file("c_src/src/dsp/dec_sse41.c")
+        .file("c_src/src/dsp/lossless_sse41.c")
         .file("c_src/src/dsp/upsampling_sse41.c")
         .file("c_src/src/dsp/yuv_sse41.c")
         .file("c_src/src/dsp/alpha_processing_sse2.c")


### PR DESCRIPTION
Seen while building `gst-plugins-rs` in Homebrew https://github.com/Homebrew/homebrew-core/pull/116170

Homebrew's Intel macOS binaries are built for Nehalem, which supports SSE4.1. The build failed on some missing symbols for SSE4.1:
```
= note: Undefined symbols for architecture x86_64:
              "_VP8LDspInitSSE41", referenced from:
                  _VP8LDspInit in liblibwebp_sys-30ac17e44a2197bd.rlib(lossless.o)
            ld: symbol(s) not found for architecture x86_64
            clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Looks like function is implemented in `src/dsp/lossless_sse41.c`: https://chromium.googlesource.com/webm/libwebp/+/b0a8608/src/dsp/lossless_sse41.c#122