### PR TITLE
impl Send on pointer wrappers

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -97,6 +97,8 @@ pub struct WebPRGBABuffer {
     pub size: usize,
 }
 
+unsafe impl Send for WebPRGBABuffer {}
+
 /// view as YUVA
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -127,6 +129,8 @@ pub struct WebPYUVABuffer {
     pub a_size: usize,
 }
 
+unsafe impl Send for WebPYUVABuffer {}
+
 /// Output buffer
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -152,6 +156,8 @@ pub struct WebPDecBuffer {
     #[doc(hidden)]
     pub private_memory: *mut u8,
 }
+
+unsafe impl Send for WebPDecBuffer {}
 
 #[allow(non_snake_case)]
 #[repr(C)]

--- a/src/demux.rs
+++ b/src/demux.rs
@@ -75,6 +75,8 @@ pub struct WebPIterator {
     pub private_: *mut c_void,
 }
 
+unsafe impl Send for WebPIterator {}
+
 #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -87,6 +89,8 @@ pub struct WebPChunkIterator {
     #[doc(hidden)]
     pub private_: *mut c_void,
 }
+
+unsafe impl Send for WebPChunkIterator {}
 
 #[cfg(all(feature = "0_5", feature = "extern-types"))]
 extern "C" {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -160,6 +160,8 @@ pub struct WebPMemoryWriter {
     pub pad: [u32; 1],
 }
 
+unsafe impl Send for WebPMemoryWriter {}
+
 pub const WEBP_MAX_DIMENSION: c_int = 16383;
 
 #[repr(C)]
@@ -206,6 +208,8 @@ pub struct WebPPicture {
     #[doc(hidden)]
     pub pad7: [*mut c_void; 2],
 }
+
+unsafe impl Send for WebPPicture {}
 
 extern "C" {
     pub fn WebPGetEncoderVersion() -> c_int;

--- a/src/mux_types.rs
+++ b/src/mux_types.rs
@@ -41,6 +41,8 @@ pub struct WebPData {
     pub size: usize,
 }
 
+unsafe impl Send for WebPData {}
+
 #[allow(non_snake_case)]
 #[inline]
 pub unsafe extern "C" fn WebPDataInit(webp_data: *mut WebPData) {


### PR DESCRIPTION
Should be safe, I think, and will make higher level API wrapping those objects Send as well, and so more convenient to use.