### PR TITLE
Migrate to doc_auto_cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Misc
   - Streamline GitHub Actions workflow for 2024 https://github.com/qnighy/libwebp-sys2-rs/pull/27
+  - Migrate to doc_auto_cfg https://github.com/qnighy/libwebp-sys2-rs/pull/28
+    - It is only relevant to the generated documentation when the nightly-only `__doc_cfg` feature is enabled.
 
 ## 0.1.10
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -13,11 +13,13 @@ cfg_if! {
 }
 
 #[cfg(feature = "extern-types")]
+#[cfg_attr(feature = "__doc_cfg", doc(cfg(all())))]
 extern "C" {
     pub type WebPIDecoder;
 }
 
 #[cfg(not(feature = "extern-types"))]
+#[cfg_attr(feature = "__doc_cfg", doc(cfg(all())))]
 #[repr(C)]
 pub struct WebPIDecoder(c_void);
 
@@ -278,11 +280,9 @@ pub struct WebPDecoderOptions {
     pub dithering_strength: c_int,
     /// if true, flip output vertically
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "0_5")))]
     pub flip: c_int,
     /// alpha dithering strength in [0..100]
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "0_5")))]
     pub alpha_dithering_strength: c_int,
     /// Unused for now. forced rotation (to be applied _last_)
     #[cfg(not(feature = "0_5"))]

--- a/src/demux.rs
+++ b/src/demux.rs
@@ -5,7 +5,6 @@ use std::ptr;
 use crate::decode::*;
 use crate::mux_types::*;
 
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
 pub const WEBP_DEMUX_ABI_VERSION: c_int = WEBP_DEMUX_ABI_VERSION_INTERNAL;
 
 cfg_if! {
@@ -17,8 +16,8 @@ cfg_if! {
 }
 
 #[cfg(feature = "extern-types")]
+#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
 extern "C" {
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
     pub type WebPDemuxer;
 }
 
@@ -27,7 +26,6 @@ extern "C" {
 #[repr(C)]
 pub struct WebPDemuxer(c_void);
 
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
 #[allow(non_camel_case_types)]
 pub type WebPDemuxState = i32;
 
@@ -36,7 +34,6 @@ pub const WEBP_DEMUX_PARSING_HEADER: WebPDemuxState = 0;
 pub const WEBP_DEMUX_PARSED_HEADER: WebPDemuxState = 1;
 pub const WEBP_DEMUX_DONE: WebPDemuxState = 2;
 
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
 #[allow(non_camel_case_types)]
 pub type WebPFormatFeature = u32;
 
@@ -47,7 +44,6 @@ pub const WEBP_FF_LOOP_COUNT: WebPFormatFeature = 3;
 pub const WEBP_FF_BACKGROUND_COLOR: WebPFormatFeature = 4;
 pub const WEBP_FF_FRAME_COUNT: WebPFormatFeature = 5;
 
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct WebPIterator {
@@ -75,7 +71,6 @@ pub struct WebPIterator {
     pub private_: *mut c_void,
 }
 
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct WebPChunkIterator {
@@ -89,11 +84,11 @@ pub struct WebPChunkIterator {
 }
 
 #[cfg(all(feature = "0_5", feature = "extern-types"))]
+#[cfg_attr(
+    feature = "__doc_cfg",
+    doc(cfg(all(feature = "demux", feature = "0_5")))
+)]
 extern "C" {
-    #[cfg_attr(
-        feature = "__doc_cfg",
-        doc(cfg(all(feature = "demux", feature = "0_5")))
-    )]
     pub type WebPAnimDecoder;
 }
 
@@ -106,10 +101,6 @@ extern "C" {
 pub struct WebPAnimDecoder(c_void);
 
 #[cfg(feature = "0_5")]
-#[cfg_attr(
-    feature = "__doc_cfg",
-    doc(cfg(all(feature = "demux", feature = "0_5")))
-)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct WebPAnimDecoderOptions {
@@ -120,10 +111,6 @@ pub struct WebPAnimDecoderOptions {
 }
 
 #[cfg(feature = "0_5")]
-#[cfg_attr(
-    feature = "__doc_cfg",
-    doc(cfg(all(feature = "demux", feature = "0_5")))
-)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct WebPAnimInfo {
@@ -137,9 +124,7 @@ pub struct WebPAnimInfo {
 }
 
 extern "C" {
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
     pub fn WebPGetDemuxVersion() -> c_int;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
     #[doc(hidden)]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPDemuxInternal(
@@ -148,33 +133,22 @@ extern "C" {
         _: *mut WebPDemuxState,
         _: c_int,
     ) -> *mut WebPDemuxer;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
     pub fn WebPDemuxDelete(dmux: *mut WebPDemuxer);
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
     pub fn WebPDemuxGetI(dmux: *const WebPDemuxer, feature: WebPFormatFeature) -> u32;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPDemuxGetFrame(
         dmux: *const WebPDemuxer,
         frame_number: c_int,
         iter: *mut WebPIterator,
     ) -> c_int;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPDemuxNextFrame(iter: *mut WebPIterator) -> c_int;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPDemuxPrevFrame(iter: *mut WebPIterator) -> c_int;
     #[cfg(not(feature = "0_5"))]
-    #[cfg_attr(
-        feature = "__doc_cfg",
-        doc(cfg(all(feature = "demux", feature = "0_5")))
-    )]
     #[deprecated(note = "Removed as of libwebp 0.5.0")]
     pub fn WebPDemuxSelectFragment(iter: *mut WebPIterator, fragment_num: c_int) -> c_int;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
     pub fn WebPDemuxReleaseIterator(iter: *mut WebPIterator);
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPDemuxGetChunk(
         dmux: *const WebPDemuxer,
@@ -182,27 +156,16 @@ extern "C" {
         chunk_number: c_int,
         iter: *mut WebPChunkIterator,
     ) -> c_int;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPDemuxNextChunk(iter: *mut WebPChunkIterator) -> c_int;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPDemuxPrevChunk(iter: *mut WebPChunkIterator) -> c_int;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
     pub fn WebPDemuxReleaseChunkIterator(iter: *mut WebPChunkIterator);
     #[cfg(feature = "0_5")]
-    #[cfg_attr(
-        feature = "__doc_cfg",
-        doc(cfg(all(feature = "demux", feature = "0_5")))
-    )]
     #[doc(hidden)]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPAnimDecoderOptionsInitInternal(_: *mut WebPAnimDecoderOptions, _: c_int) -> c_int;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(
-        feature = "__doc_cfg",
-        doc(cfg(all(feature = "demux", feature = "0_5")))
-    )]
     #[doc(hidden)]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPAnimDecoderNewInternal(
@@ -211,17 +174,9 @@ extern "C" {
         _: c_int,
     ) -> *mut WebPAnimDecoder;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(
-        feature = "__doc_cfg",
-        doc(cfg(all(feature = "demux", feature = "0_5")))
-    )]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPAnimDecoderGetInfo(dec: *const WebPAnimDecoder, info: *mut WebPAnimInfo) -> c_int;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(
-        feature = "__doc_cfg",
-        doc(cfg(all(feature = "demux", feature = "0_5")))
-    )]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPAnimDecoderGetNext(
         dec: *mut WebPAnimDecoder,
@@ -229,34 +184,17 @@ extern "C" {
         timestamp: *mut c_int,
     ) -> c_int;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(
-        feature = "__doc_cfg",
-        doc(cfg(all(feature = "demux", feature = "0_5")))
-    )]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPAnimDecoderHasMoreFrames(dec: *const WebPAnimDecoder) -> c_int;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(
-        feature = "__doc_cfg",
-        doc(cfg(all(feature = "demux", feature = "0_5")))
-    )]
     pub fn WebPAnimDecoderReset(dec: *mut WebPAnimDecoder);
     #[cfg(feature = "0_5")]
-    #[cfg_attr(
-        feature = "__doc_cfg",
-        doc(cfg(all(feature = "demux", feature = "0_5")))
-    )]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPAnimDecoderGetDemuxer(dec: *const WebPAnimDecoder) -> *const WebPDemuxer;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(
-        feature = "__doc_cfg",
-        doc(cfg(all(feature = "demux", feature = "0_5")))
-    )]
     pub fn WebPAnimDecoderDelete(dec: *mut WebPAnimDecoder);
 }
 
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
 #[allow(non_snake_case)]
 #[cfg_attr(feature = "must-use", must_use)]
 #[inline]
@@ -264,7 +202,6 @@ pub unsafe extern "C" fn WebPDemux(data: *const WebPData) -> *mut WebPDemuxer {
     WebPDemuxInternal(data, 0, ptr::null_mut(), WEBP_DEMUX_ABI_VERSION)
 }
 
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "demux")))]
 #[allow(non_snake_case)]
 #[cfg_attr(feature = "must-use", must_use)]
 #[inline]
@@ -276,10 +213,6 @@ pub unsafe extern "C" fn WebPDemuxPartial(
 }
 
 #[cfg(feature = "0_5")]
-#[cfg_attr(
-    feature = "__doc_cfg",
-    doc(cfg(all(feature = "demux", feature = "0_5")))
-)]
 #[allow(non_snake_case)]
 #[inline]
 #[cfg_attr(feature = "must-use", must_use)]
@@ -290,10 +223,6 @@ pub unsafe extern "C" fn WebPAnimDecoderOptionsInit(
 }
 
 #[cfg(feature = "0_5")]
-#[cfg_attr(
-    feature = "__doc_cfg",
-    doc(cfg(all(feature = "demux", feature = "0_5")))
-)]
 #[allow(non_snake_case)]
 #[cfg_attr(feature = "must-use", must_use)]
 #[inline]

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -51,22 +51,16 @@ pub struct WebPConfig {
     pub thread_level: c_int,
     pub low_memory: c_int,
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "0_5")))]
     pub near_lossless: c_int,
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "0_5")))]
     pub exact: c_int,
     #[cfg(feature = "0_6")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "0_6")))]
     pub use_delta_palette: c_int,
     #[cfg(feature = "0_6")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "0_6")))]
     pub use_sharp_yuv: c_int,
     #[cfg(feature = "1_2")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "1_2")))]
     pub qmin: c_int,
     #[cfg(feature = "1_2")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "1_2")))]
     pub qmax: c_int,
     #[cfg(not(feature = "0_5"))]
     #[doc(hidden)]
@@ -110,13 +104,10 @@ pub struct WebPAuxStats {
     pub palette_size: c_int,
     pub lossless_size: c_int,
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "0_5")))]
     pub lossless_hdr_size: c_int,
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "0_5")))]
     pub lossless_data_size: c_int,
     #[cfg(feature = "1_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "1_5")))]
     pub cross_color_transform_bits: c_int,
     #[cfg(not(feature = "0_5"))]
     #[doc(hidden)]
@@ -282,14 +273,12 @@ extern "C" {
     pub fn WebPConfigInitInternal(_: *mut WebPConfig, _: WebPPreset, _: c_float, _: c_int)
         -> c_int;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "0_5")))]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPConfigLosslessPreset(config: *mut WebPConfig, level: c_int) -> c_int;
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPValidateConfig(config: *const WebPConfig) -> c_int;
     pub fn WebPMemoryWriterInit(writer: *mut WebPMemoryWriter);
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "0_5")))]
     pub fn WebPMemoryWriterClear(writer: *mut WebPMemoryWriter);
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPMemoryWrite(data: *const u8, data_size: usize, picture: *const WebPPicture)
@@ -303,7 +292,6 @@ extern "C" {
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPPictureCopy(src: *const WebPPicture, dst: *mut WebPPicture) -> c_int;
     #[cfg(feature = "0_6")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "0_6")))]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPPlaneDistortion(
         src: *const u8,
@@ -389,11 +377,9 @@ extern "C" {
         dithering: c_float,
     ) -> c_int;
     #[cfg(feature = "0_6")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "0_6")))]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPPictureSharpARGBToYUVA(picture: *mut WebPPicture) -> c_int;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "0_5")))]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPPictureSmartARGBToYUVA(picture: *mut WebPPicture) -> c_int;
     #[cfg_attr(feature = "must-use", must_use)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "__doc_cfg", feature(doc_cfg))]
+#![cfg_attr(feature = "__doc_cfg", feature(doc_auto_cfg))]
 #![cfg_attr(feature = "extern-types", feature(extern_types))]
 
 #[macro_use]

--- a/src/mux.rs
+++ b/src/mux.rs
@@ -4,7 +4,6 @@ use std::os::raw::*;
 use crate::encode::{WebPConfig, WebPPicture};
 use crate::mux_types::*;
 
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
 pub const WEBP_MUX_ABI_VERSION: c_int = WEBP_MUX_ABI_VERSION_INTERNAL;
 
 cfg_if! {
@@ -20,8 +19,8 @@ cfg_if! {
 }
 
 #[cfg(feature = "extern-types")]
+#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
 extern "C" {
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     pub type WebPMux;
 }
 
@@ -30,25 +29,17 @@ extern "C" {
 #[repr(C)]
 pub struct WebPMux(c_void);
 
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
 #[allow(non_camel_case_types)]
 // #[cfg_attr(feature = "must-use", must_use)] // meaningless for type aliases
 pub type WebPMuxError = i32;
 
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
 pub const WEBP_MUX_OK: WebPMuxError = 1;
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
 pub const WEBP_MUX_NOT_FOUND: WebPMuxError = 0;
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
 pub const WEBP_MUX_INVALID_ARGUMENT: WebPMuxError = -1;
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
 pub const WEBP_MUX_BAD_DATA: WebPMuxError = -2;
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
 pub const WEBP_MUX_MEMORY_ERROR: WebPMuxError = -3;
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
 pub const WEBP_MUX_NOT_ENOUGH_DATA: WebPMuxError = -4;
 
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
 #[allow(non_camel_case_types)]
 pub type WebPChunkId = u32;
 
@@ -68,7 +59,6 @@ pub const WEBP_CHUNK_XMP: WebPChunkId = 8;
 pub const WEBP_CHUNK_UNKNOWN: WebPChunkId = 9;
 pub const WEBP_CHUNK_NIL: WebPChunkId = 10;
 
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct WebPMuxFrameInfo {
@@ -83,7 +73,6 @@ pub struct WebPMuxFrameInfo {
     pub pad: [u32; 1],
 }
 
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct WebPMuxAnimParams {
@@ -92,18 +81,17 @@ pub struct WebPMuxAnimParams {
 }
 
 #[cfg(all(feature = "0_5", feature = "extern-types"))]
+#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "0_5")))]
 extern "C" {
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(all(feature = "mux", feature = "0_5"))))]
     pub type WebPAnimEncoder;
 }
 
 #[cfg(all(feature = "0_5", not(feature = "extern-types")))]
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(all(feature = "mux", feature = "0_5"))))]
+#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "0_5")))]
 #[repr(C)]
 pub struct WebPAnimEncoder(c_void);
 
 #[cfg(feature = "0_5")]
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(all(feature = "mux", feature = "0_5"))))]
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct WebPAnimEncoderOptions {
@@ -118,87 +106,68 @@ pub struct WebPAnimEncoderOptions {
 }
 
 extern "C" {
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     pub fn WebPGetMuxVersion() -> c_int;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     #[doc(hidden)]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPNewInternal(_: c_int) -> *mut WebPMux;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     pub fn WebPMuxDelete(mux: *mut WebPMux);
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     #[doc(hidden)]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPMuxCreateInternal(_: *const WebPData, _: c_int, _: c_int) -> *mut WebPMux;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     pub fn WebPMuxSetChunk(
         mux: *mut WebPMux,
         fourcc: *const c_char,
         chunk_data: *const WebPData,
         copy_data: c_int,
     ) -> WebPMuxError;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     pub fn WebPMuxGetChunk(
         mux: *const WebPMux,
         fourcc: *const c_char,
         chunk_data: *mut WebPData,
     ) -> WebPMuxError;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     pub fn WebPMuxDeleteChunk(mux: *mut WebPMux, fourcc: *const c_char) -> WebPMuxError;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     pub fn WebPMuxSetImage(
         mux: *mut WebPMux,
         bitstream: *const WebPData,
         copy_data: c_int,
     ) -> WebPMuxError;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     pub fn WebPMuxPushFrame(
         mux: *mut WebPMux,
         frame: *const WebPMuxFrameInfo,
         copy_data: c_int,
     ) -> WebPMuxError;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     pub fn WebPMuxGetFrame(
         mux: *const WebPMux,
         nth: u32,
         frame: *mut WebPMuxFrameInfo,
     ) -> WebPMuxError;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     pub fn WebPMuxDeleteFrame(mux: *mut WebPMux, nth: u32) -> WebPMuxError;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     pub fn WebPMuxSetAnimationParams(
         mux: *mut WebPMux,
         params: *const WebPMuxAnimParams,
     ) -> WebPMuxError;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     pub fn WebPMuxGetAnimationParams(
         mux: *const WebPMux,
         params: *mut WebPMuxAnimParams,
     ) -> WebPMuxError;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(all(feature = "mux", feature = "0_5"))))]
     pub fn WebPMuxSetCanvasSize(mux: *mut WebPMux, width: c_int, height: c_int) -> WebPMuxError;
     pub fn WebPMuxGetCanvasSize(
         mux: *const WebPMux,
         width: *mut c_int,
         height: *mut c_int,
     ) -> WebPMuxError;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     pub fn WebPMuxGetFeatures(mux: *const WebPMux, flags: *mut u32) -> WebPMuxError;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     pub fn WebPMuxNumChunks(
         mux: *const WebPMux,
         id: WebPChunkId,
         num_elements: *mut c_int,
     ) -> WebPMuxError;
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
     pub fn WebPMuxAssemble(mux: *mut WebPMux, assembled_data: *mut WebPData) -> WebPMuxError;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(all(feature = "mux", feature = "0_5"))))]
     #[doc(hidden)]
     pub fn WebPAnimEncoderOptionsInitInternal(_: *mut WebPAnimEncoderOptions, _: c_int) -> c_int;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(all(feature = "mux", feature = "0_5"))))]
     #[doc(hidden)]
     pub fn WebPAnimEncoderNewInternal(
         _: c_int,
@@ -207,7 +176,6 @@ extern "C" {
         _: c_int,
     ) -> *mut WebPAnimEncoder;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(all(feature = "mux", feature = "0_5"))))]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPAnimEncoderAdd(
         enc: *mut WebPAnimEncoder,
@@ -216,17 +184,13 @@ extern "C" {
         config: *const WebPConfig,
     ) -> c_int;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(all(feature = "mux", feature = "0_5"))))]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPAnimEncoderAssemble(enc: *mut WebPAnimEncoder, webp_data: *mut WebPData) -> c_int;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(all(feature = "mux", feature = "0_5"))))]
     pub fn WebPAnimEncoderGetError(enc: *mut WebPAnimEncoder) -> *const c_char;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(all(feature = "mux", feature = "0_5"))))]
     pub fn WebPAnimEncoderDelete(enc: *mut WebPAnimEncoder);
     #[cfg(feature = "1_4")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(all(feature = "mux", feature = "1_4"))))]
     pub fn WebPAnimEncoderSetChunk(
         enc: *mut WebPAnimEncoder,
         fourcc: *const c_char,
@@ -234,21 +198,18 @@ extern "C" {
         copy_data: c_int,
     ) -> WebPMuxError;
     #[cfg(feature = "1_4")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(all(feature = "mux", feature = "1_4"))))]
     pub fn WebPAnimEncoderGetChunk(
         enc: *const WebPAnimEncoder,
         fourcc: *const c_char,
         chunk_data: *mut WebPData,
     ) -> WebPMuxError;
     #[cfg(feature = "1_4")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(all(feature = "mux", feature = "1_4"))))]
     pub fn WebPAnimEncoderDeleteChunk(
         enc: *mut WebPAnimEncoder,
         fourcc: *const c_char,
     ) -> WebPMuxError;
 }
 
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
 #[allow(non_snake_case)]
 #[cfg_attr(feature = "must-use", must_use)]
 #[inline]
@@ -256,7 +217,6 @@ pub unsafe extern "C" fn WebPMuxNew() -> *mut WebPMux {
     WebPNewInternal(WEBP_MUX_ABI_VERSION)
 }
 
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "mux")))]
 #[allow(non_snake_case)]
 #[cfg_attr(feature = "must-use", must_use)]
 #[inline]
@@ -268,7 +228,6 @@ pub unsafe extern "C" fn WebPMuxCreate(
 }
 
 #[cfg(feature = "0_5")]
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(all(feature = "mux", feature = "0_5"))))]
 #[allow(non_snake_case)]
 #[cfg_attr(feature = "must-use", must_use)]
 #[inline]
@@ -279,7 +238,6 @@ pub unsafe extern "C" fn WebPAnimEncoderOptionsInit(
 }
 
 #[cfg(feature = "0_5")]
-#[cfg_attr(feature = "__doc_cfg", doc(cfg(all(feature = "mux", feature = "0_5"))))]
 #[allow(non_snake_case)]
 #[inline]
 pub unsafe extern "C" fn WebPAnimEncoderNew(

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,11 +13,9 @@ extern "C" {
     /// must be deallocated by calling `WebPFree()`. This function is made available
     /// by the core `libwebp` library.
     #[cfg(feature = "1_1")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "1_1")))]
     #[cfg_attr(feature = "must-use", must_use)]
     pub fn WebPMalloc(size: usize) -> *mut c_void;
     /// Releases memory returned by the `WebPDecode*()` functions (from `decode.h`).
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "__doc_cfg", doc(cfg(feature = "0_5")))]
     pub fn WebPFree(ptr: *mut c_void);
 }


### PR DESCRIPTION
There is now [doc_auto_cfg](https://doc.rust-lang.org/beta/unstable-book/language-features/doc-auto-cfg.html) which is more convenient.