### PR TITLE
Rework features for next version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,32 +11,32 @@ jobs:
         rust: [stable]
         webp: [0.4.4, 0.5.2, 1.0.3, 1.1.0, 1.2.0, 1.4.0, 1.5.0]
         webp_from: ["build"]
-        common_features: [""]
+        common_features: ["std,"]
         include:
         - rust: stable
           webp: 1.3.2
           webp_from: distr
-          common_features: ""
+          common_features: std,
         - rust: stable
           webp: 1.5.0
           webp_from: bundled
-          common_features: ""
+          common_features: std,
         - rust: 1.85.0
           webp: 1.5.0
           webp_from: build
-          common_features: ""
+          common_features: std,
         - rust: beta
           webp: 1.5.0
           webp_from: build
-          common_features: ""
+          common_features: std,
         - rust: nightly
           webp: 1.5.0
           webp_from: build
-          common_features: ""
+          common_features: std,
         - rust: nightly
           webp: 1.5.0
           webp_from: build
-          common_features: extern-types,
+          common_features: std,extern-types,
 
     steps:
     - uses: actions/checkout@v4
@@ -70,62 +70,62 @@ jobs:
       if: matrix.rust == '1.85.0'
     - name: Test 0.4
       run: |
-        cargo test --all --features "${{ matrix.common_features }}"
-        cargo test --all --features "${{ matrix.common_features }}demux"
-        cargo test --all --features "${{ matrix.common_features }}mux"
-        cargo test --all --features "${{ matrix.common_features }}demux,mux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}demux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}mux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}demux,mux"
     - name: Test 0.5
       run: |
-        cargo test --all --features "${{ matrix.common_features }}0_5"
-        cargo test --all --features "${{ matrix.common_features }}0_5,demux"
-        cargo test --all --features "${{ matrix.common_features }}0_5,mux"
-        cargo test --all --features "${{ matrix.common_features }}0_5,demux,mux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}0_5"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}0_5,demux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}0_5,mux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}0_5,demux,mux"
       if: matrix.webp >= '0.5'
     - name: Test 0.6
       run: |
-        cargo test --all --features "${{ matrix.common_features }}0_6"
-        cargo test --all --features "${{ matrix.common_features }}0_6,demux"
-        cargo test --all --features "${{ matrix.common_features }}0_6,mux"
-        cargo test --all --features "${{ matrix.common_features }}0_6,demux,mux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}0_6"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}0_6,demux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}0_6,mux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}0_6,demux,mux"
       if: matrix.webp >= '0.6'
     - name: Test 1.1
       run: |
-        cargo test --all --features "${{ matrix.common_features }}1_1"
-        cargo test --all --features "${{ matrix.common_features }}1_1,demux"
-        cargo test --all --features "${{ matrix.common_features }}1_1,mux"
-        cargo test --all --features "${{ matrix.common_features }}1_1,demux,mux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_1"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_1,demux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_1,mux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_1,demux,mux"
       if: matrix.webp >= '1.1'
     - name: Test 1.2
       run: |
-        cargo test --all --features "${{ matrix.common_features }}1_2"
-        cargo test --all --features "${{ matrix.common_features }}1_2,demux"
-        cargo test --all --features "${{ matrix.common_features }}1_2,mux"
-        cargo test --all --features "${{ matrix.common_features }}1_2,demux,mux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_2"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_2,demux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_2,mux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_2,demux,mux"
       if: matrix.webp >= '1.2'
     - name: Test 1.4
       run: |
-        cargo test --all --features "${{ matrix.common_features }}1_4"
-        cargo test --all --features "${{ matrix.common_features }}1_4,demux"
-        cargo test --all --features "${{ matrix.common_features }}1_4,mux"
-        cargo test --all --features "${{ matrix.common_features }}1_4,demux,mux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_4"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_4,demux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_4,mux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_4,demux,mux"
       if: matrix.webp >= '1.4'
     - name: Test 1.5
       run: |
-        cargo test --all --features "${{ matrix.common_features }}1_5"
-        cargo test --all --features "${{ matrix.common_features }}1_5,demux"
-        cargo test --all --features "${{ matrix.common_features }}1_5,mux"
-        cargo test --all --features "${{ matrix.common_features }}1_5,demux,mux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_5"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_5,demux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_5,mux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_5,demux,mux"
       if: matrix.webp >= '1.5'
     - name: Test static builds
       run: |
-        cargo test --all --features "${{ matrix.common_features }}1_5,static"
-        cargo test --all --features "${{ matrix.common_features }}1_5,static,demux"
-        cargo test --all --features "${{ matrix.common_features }}1_5,static,mux"
-        cargo test --all --features "${{ matrix.common_features }}1_5,static,demux,mux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_5,static"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_5,static,demux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_5,static,mux"
+        cargo test --all --no-default-features --features "${{ matrix.common_features }}1_5,static,demux,mux"
       if: matrix.webp_from == 'bundled'
     - name: Test __doc_cfg
       run: |
-        cargo doc --all --features "${{ matrix.common_features }}__doc_cfg"
+        cargo doc --all --no-default-features --features "${{ matrix.common_features }}__doc_cfg"
       if: matrix.rust == 'nightly'
     - name: Check format
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Breaking changes
   - Migrate to Rust 2024 and raise MSRV to 1.85.0 https://github.com/qnighy/libwebp-sys2-rs/pull/30
+  - Changed to crate features https://github.com/qnighy/libwebp-sys2-rs/pull/31
+    - Add `std` default feature. This is currently required for the crate to be compiled.
+    - Make `1_2` default. If you need to support libwebp versions older than 1.2.0, you should opt out of it using default-features = false.
+    - Remove `must-use`. Now `#[must_use]` annotation is always added to the relevant definitions.
 
 ## 0.1.11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ cfg-if = "1.0.0"
 libc = "0.2.169"
 
 [features]
-default = []
+default = ["std", "1_2"]
+std = []
 demux = []
 mux = []
 "0_5" = []
@@ -40,11 +41,10 @@ mux = []
 "1_5" = ["1_4"]
 static = []
 extern-types = []
-must-use = []
 __doc_cfg = ["1_5", "demux", "mux"]
 
 [package.metadata.docs.rs]
-features = ["1_5", "demux", "mux", "__doc_cfg", "extern-types", "must-use"]
+features = ["1_5", "demux", "mux", "__doc_cfg", "extern-types"]
 
 [build-dependencies]
 pkg-config = "0.3.31"

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -171,7 +171,7 @@ impl std::fmt::Debug for __WebPDecBufferUnion {
 
 /// Enumeration of the status codes
 #[allow(non_camel_case_types)]
-// #[cfg_attr(feature = "must-use", must_use)] // meaningless for type aliases
+// #[must_use] // meaningless for type aliases
 pub type VP8StatusCode = u32;
 
 pub const VP8_STATUS_OK: VP8StatusCode = 0;
@@ -325,7 +325,7 @@ unsafe extern "C" {
     /// RIFF + VP8X + (optional chunks) + VP8(L)
     /// ALPH + VP8 <-- Not a valid WebP format: only allowed for internal purpose.
     /// VP8(L)     <-- Not a valid WebP format: only allowed for internal purpose.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPGetInfo(
         data: *const u8,
         data_size: usize,
@@ -337,7 +337,7 @@ unsafe extern "C" {
     /// memory is R, G, B, A, R, G, B, A... in scan order (endian-independent).
     /// The returned pointer should be deleted calling WebPFree().
     /// Returns NULL in case of error.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDecodeRGBA(
         data: *const u8,
         data_size: usize,
@@ -345,7 +345,7 @@ unsafe extern "C" {
         height: *mut c_int,
     ) -> *mut u8;
     /// Same as WebPDecodeRGBA, but returning A, R, G, B, A, R, G, B... ordered data.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDecodeARGB(
         data: *const u8,
         data_size: usize,
@@ -353,7 +353,7 @@ unsafe extern "C" {
         height: *mut c_int,
     ) -> *mut u8;
     /// Same as WebPDecodeRGBA, but returning B, G, R, A, B, G, R, A... ordered data.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDecodeBGRA(
         data: *const u8,
         data_size: usize,
@@ -362,7 +362,7 @@ unsafe extern "C" {
     ) -> *mut u8;
     /// Same as WebPDecodeRGBA, but returning R, G, B, R, G, B... ordered data.
     /// If the bitstream contains transparency, it is ignored.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDecodeRGB(
         data: *const u8,
         data_size: usize,
@@ -370,7 +370,7 @@ unsafe extern "C" {
         height: *mut c_int,
     ) -> *mut u8;
     /// Same as WebPDecodeRGB, but returning B, G, R, B, G, R... ordered data.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDecodeBGR(
         data: *const u8,
         data_size: usize,
@@ -387,7 +387,7 @@ unsafe extern "C" {
     /// 'width' and 'height' may be NULL, the other pointers must not be.
     /// Returns NULL in case of error.
     /// (*) Also named Y'CbCr. See: <https://en.wikipedia.org/wiki/YCbCr>
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDecodeYUV(
         data: *const u8,
         data_size: usize,
@@ -406,7 +406,7 @@ unsafe extern "C" {
     // The parameter 'output_stride' specifies the distance (in bytes)
     // between scanlines. Hence, output_buffer_size is expected to be at least
     // output_stride x picture-height.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDecodeRGBAInto(
         data: *const u8,
         data_size: usize,
@@ -414,7 +414,7 @@ unsafe extern "C" {
         output_buffer_size: usize,
         output_stride: c_int,
     ) -> *mut u8;
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDecodeARGBInto(
         data: *const u8,
         data_size: usize,
@@ -422,7 +422,7 @@ unsafe extern "C" {
         output_buffer_size: usize,
         output_stride: c_int,
     ) -> *mut u8;
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDecodeBGRAInto(
         data: *const u8,
         data_size: usize,
@@ -432,7 +432,7 @@ unsafe extern "C" {
     ) -> *mut u8;
     // RGB and BGR variants. Here too the transparency information, if present,
     // will be dropped and ignored.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDecodeRGBInto(
         data: *const u8,
         data_size: usize,
@@ -440,7 +440,7 @@ unsafe extern "C" {
         output_buffer_size: usize,
         output_stride: c_int,
     ) -> *mut u8;
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDecodeBGRInto(
         data: *const u8,
         data_size: usize,
@@ -455,7 +455,7 @@ unsafe extern "C" {
     /// 'u_size' and 'v_size' respectively.
     /// Pointer to the luma plane ('*luma') is returned or NULL if an error occurred
     /// during decoding (or because some buffers were found to be too small).
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDecodeYUVInto(
         data: *const u8,
         data_size: usize,
@@ -471,7 +471,7 @@ unsafe extern "C" {
     ) -> *mut u8;
     /// Internal, version-checked, entry point
     #[doc(hidden)]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPInitDecBufferInternal(_: *mut WebPDecBuffer, _: c_int) -> c_int;
     /// Free any memory associated with the buffer. Must always be called last.
     /// Note: doesn't free the 'buffer' structure itself.
@@ -488,7 +488,7 @@ unsafe extern "C" {
     /// within valid bounds.
     /// All other fields of WebPDecBuffer MUST remain constant between calls.
     /// Returns NULL if the allocation failed.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPINewDecoder(output_buffer: *mut WebPDecBuffer) -> *mut WebPIDecoder;
     /// This function allocates and initializes an incremental-decoder object, which
     /// will output the RGB/A samples specified by 'csp' into a preallocated
@@ -500,7 +500,7 @@ unsafe extern "C" {
     /// colorspace 'csp' is taken into account for allocating this buffer. All other
     /// parameters are ignored.
     /// Returns NULL if the allocation failed, or if some parameters are invalid.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPINewRGB(
         csp: WEBP_CSP_MODE,
         output_buffer: *mut u8,
@@ -518,7 +518,7 @@ unsafe extern "C" {
     /// In this case, the output buffer will be automatically allocated (using
     /// MODE_YUVA) when decoding starts. All parameters are then ignored.
     /// Returns NULL if the allocation failed or if a parameter is invalid.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPINewYUVA(
         luma: *mut u8,
         luma_size: usize,
@@ -535,7 +535,7 @@ unsafe extern "C" {
     ) -> *mut WebPIDecoder;
     /// Deprecated version of the above, without the alpha plane.
     /// Kept for backward compatibility.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPINewYUV(
         luma: *mut u8,
         luma_size: usize,
@@ -569,7 +569,7 @@ unsafe extern "C" {
     /// (*last_y, *width etc.) can be NULL if corresponding information is not
     /// needed. The values in these pointers are only valid on successful (non-NULL)
     /// return.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPIDecGetRGB(
         idec: *const WebPIDecoder,
         last_y: *mut c_int,
@@ -580,7 +580,7 @@ unsafe extern "C" {
     /// Same as above function to get a YUVA image. Returns pointer to the luma
     /// plane or NULL in case of error. If there is no alpha information
     /// the alpha pointer '*a' will be returned NULL.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPIDecGetYUVA(
         idec: *const WebPIDecoder,
         last_y: *mut c_int,
@@ -599,7 +599,7 @@ unsafe extern "C" {
     /// Returns NULL in case the incremental decoder object is in an invalid state.
     /// Otherwise returns the pointer to the internal representation. This structure
     /// is read-only, tied to WebPIDecoder's lifespan and should not be modified.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPIDecodedArea(
         idec: *const WebPIDecoder,
         left: *mut c_int,
@@ -617,7 +617,7 @@ unsafe extern "C" {
     ) -> VP8StatusCode;
     /// Internal, version-checked, entry point
     #[doc(hidden)]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPInitDecoderConfigInternal(_: *mut WebPDecoderConfig, _: c_int) -> c_int;
     /// Instantiate a new incremental decoder object with the requested
     /// configuration. The bitstream can be passed using 'data' and 'data_size'
@@ -630,7 +630,7 @@ unsafe extern "C" {
     /// The return WebPIDecoder object must always be deleted calling WebPIDelete().
     /// Returns NULL in case of error (and config->status will then reflect
     /// the error condition, if available).
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPIDecode(
         data: *const u8,
         data_size: usize,
@@ -649,7 +649,7 @@ unsafe extern "C" {
 /// Initialize the structure as empty. Must be called before any other use.
 /// Returns false in case of version mismatch
 #[allow(non_snake_case)]
-#[cfg_attr(feature = "must-use", must_use)]
+#[must_use]
 #[inline]
 pub unsafe extern "C" fn WebPInitDecBuffer(buffer: *mut WebPDecBuffer) -> c_int {
     unsafe { WebPInitDecBufferInternal(buffer, WEBP_DECODER_ABI_VERSION) }
@@ -680,7 +680,7 @@ pub unsafe extern "C" fn WebPGetFeatures(
 /// called first, unless WebPGetFeatures() is to be called.
 /// Returns false in case of mismatched version.
 #[allow(non_snake_case)]
-#[cfg_attr(feature = "must-use", must_use)]
+#[must_use]
 #[inline]
 pub unsafe extern "C" fn WebPInitDecoderConfig(config: *mut WebPDecoderConfig) -> c_int {
     unsafe { WebPInitDecoderConfigInternal(config, WEBP_DECODER_ABI_VERSION) }

--- a/src/demux.rs
+++ b/src/demux.rs
@@ -126,7 +126,7 @@ pub struct WebPAnimInfo {
 unsafe extern "C" {
     pub fn WebPGetDemuxVersion() -> c_int;
     #[doc(hidden)]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDemuxInternal(
         _: *const WebPData,
         _: c_int,
@@ -135,75 +135,75 @@ unsafe extern "C" {
     ) -> *mut WebPDemuxer;
     pub fn WebPDemuxDelete(dmux: *mut WebPDemuxer);
     pub fn WebPDemuxGetI(dmux: *const WebPDemuxer, feature: WebPFormatFeature) -> u32;
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDemuxGetFrame(
         dmux: *const WebPDemuxer,
         frame_number: c_int,
         iter: *mut WebPIterator,
     ) -> c_int;
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDemuxNextFrame(iter: *mut WebPIterator) -> c_int;
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDemuxPrevFrame(iter: *mut WebPIterator) -> c_int;
     #[cfg(not(feature = "0_5"))]
     #[deprecated(note = "Removed as of libwebp 0.5.0")]
     pub fn WebPDemuxSelectFragment(iter: *mut WebPIterator, fragment_num: c_int) -> c_int;
     pub fn WebPDemuxReleaseIterator(iter: *mut WebPIterator);
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDemuxGetChunk(
         dmux: *const WebPDemuxer,
         fourcc: *const c_char,
         chunk_number: c_int,
         iter: *mut WebPChunkIterator,
     ) -> c_int;
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDemuxNextChunk(iter: *mut WebPChunkIterator) -> c_int;
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPDemuxPrevChunk(iter: *mut WebPChunkIterator) -> c_int;
     pub fn WebPDemuxReleaseChunkIterator(iter: *mut WebPChunkIterator);
     #[cfg(feature = "0_5")]
     #[doc(hidden)]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPAnimDecoderOptionsInitInternal(_: *mut WebPAnimDecoderOptions, _: c_int) -> c_int;
     #[cfg(feature = "0_5")]
     #[doc(hidden)]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPAnimDecoderNewInternal(
         _: *const WebPData,
         _: *const WebPAnimDecoderOptions,
         _: c_int,
     ) -> *mut WebPAnimDecoder;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPAnimDecoderGetInfo(dec: *const WebPAnimDecoder, info: *mut WebPAnimInfo) -> c_int;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPAnimDecoderGetNext(
         dec: *mut WebPAnimDecoder,
         buf: *mut *mut u8,
         timestamp: *mut c_int,
     ) -> c_int;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPAnimDecoderHasMoreFrames(dec: *const WebPAnimDecoder) -> c_int;
     #[cfg(feature = "0_5")]
     pub fn WebPAnimDecoderReset(dec: *mut WebPAnimDecoder);
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPAnimDecoderGetDemuxer(dec: *const WebPAnimDecoder) -> *const WebPDemuxer;
     #[cfg(feature = "0_5")]
     pub fn WebPAnimDecoderDelete(dec: *mut WebPAnimDecoder);
 }
 
 #[allow(non_snake_case)]
-#[cfg_attr(feature = "must-use", must_use)]
+#[must_use]
 #[inline]
 pub unsafe extern "C" fn WebPDemux(data: *const WebPData) -> *mut WebPDemuxer {
     unsafe { WebPDemuxInternal(data, 0, ptr::null_mut(), WEBP_DEMUX_ABI_VERSION) }
 }
 
 #[allow(non_snake_case)]
-#[cfg_attr(feature = "must-use", must_use)]
+#[must_use]
 #[inline]
 pub unsafe extern "C" fn WebPDemuxPartial(
     data: *const WebPData,
@@ -215,7 +215,7 @@ pub unsafe extern "C" fn WebPDemuxPartial(
 #[cfg(feature = "0_5")]
 #[allow(non_snake_case)]
 #[inline]
-#[cfg_attr(feature = "must-use", must_use)]
+#[must_use]
 pub unsafe extern "C" fn WebPAnimDecoderOptionsInit(
     dec_options: *mut WebPAnimDecoderOptions,
 ) -> c_int {
@@ -224,7 +224,7 @@ pub unsafe extern "C" fn WebPAnimDecoderOptionsInit(
 
 #[cfg(feature = "0_5")]
 #[allow(non_snake_case)]
-#[cfg_attr(feature = "must-use", must_use)]
+#[must_use]
 #[inline]
 pub unsafe extern "C" fn WebPAnimDecoderNew(
     webp_data: *const WebPData,

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -507,7 +507,7 @@ unsafe extern "C" {
     ) -> usize;
     /// Internal, version-checked, entry point
     #[doc(hidden)]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPConfigInitInternal(_: *mut WebPConfig, _: WebPPreset, _: c_float, _: c_int)
     -> c_int;
     /// Activate the lossless compression mode with the desired efficiency level
@@ -517,11 +517,11 @@ unsafe extern "C" {
     /// This function will overwrite several fields from config: `method`, `quality`
     /// and `lossless`. Returns false in case of parameter error.
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPConfigLosslessPreset(config: *mut WebPConfig, level: c_int) -> c_int;
     /// Returns true if `config` is non-NULL and all configuration parameters are
     /// within their valid ranges.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPValidateConfig(config: *const WebPConfig) -> c_int;
     /// The following must be called first before any use.
     pub fn WebPMemoryWriterInit(writer: *mut WebPMemoryWriter);
@@ -532,18 +532,18 @@ unsafe extern "C" {
     /// The custom writer to be used with WebPMemoryWriter as custom_ptr. Upon
     /// completion, writer.mem and writer.size will hold the coded data.
     /// writer.mem must be freed by calling WebPMemoryWriterClear.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPMemoryWrite(data: *const u8, data_size: usize, picture: *const WebPPicture)
     -> c_int;
     /// Internal, version-checked, entry point
     #[doc(hidden)]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureInitInternal(_: *mut WebPPicture, _: c_int) -> c_int;
     /// Convenience allocation / deallocation based on picture->width/height:
     /// Allocate y/u/v buffers as per colorspace/width/height specification.
     /// Note! This function will free the previous buffer if needed.
     /// Returns false in case of memory error.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureAlloc(picture: *mut WebPPicture) -> c_int;
     /// Release the memory allocated by WebPPictureAlloc() or WebPPictureImport\*().
     /// Note that this function does _not_ free the memory used by the `picture`
@@ -555,7 +555,7 @@ unsafe extern "C" {
     /// will fully own the copied pixels (this is not a view). The `dst` picture need
     /// not be initialized as its content is overwritten.
     /// Returns false in case of memory allocation error.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureCopy(src: *const WebPPicture, dst: *mut WebPPicture) -> c_int;
     /// Compute the single distortion for packed planes of samples.
     /// `src` will be compared to `ref`, and the raw distortion stored into
@@ -565,7 +565,7 @@ unsafe extern "C" {
     /// `src/ref_stride` is the byte distance between rows.
     /// Returns false in case of error (bad parameter, memory allocation error, ...).
     #[cfg(feature = "0_6")]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPlaneDistortion(
         src: *const u8,
         src_stride: usize,
@@ -583,7 +583,7 @@ unsafe extern "C" {
     /// always performed using ARGB samples. Hence if the input is YUV(A), the
     /// picture will be internally converted to ARGB (just for the measurement).
     /// Warning: this function is rather CPU-intensive.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureDistortion(
         src: *const WebPPicture,
         ref_: *const WebPPicture,
@@ -598,7 +598,7 @@ unsafe extern "C" {
     /// must be fully be comprised inside the `src` source picture. If the source
     /// picture uses the YUV420 colorspace, the top and left coordinates will be
     /// snapped to even values.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureCrop(
         picture: *mut WebPPicture,
         left: c_int,
@@ -617,7 +617,7 @@ unsafe extern "C" {
     /// with WebPPictureInit() if it is different from `src`, since its content will
     /// be overwritten.
     /// Returns false in case of invalid parameters.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureView(
         src: *const WebPPicture,
         left: c_int,
@@ -634,20 +634,20 @@ unsafe extern "C" {
     /// dimension will be calculated preserving the aspect ratio.
     /// No gamma correction is applied.
     /// Returns false in case of error (invalid parameter or insufficient memory).
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureRescale(picture: *mut WebPPicture, width: c_int, height: c_int) -> c_int;
     /// Colorspace conversion function to import RGB samples.
     /// Previous buffer will be free'd, if any.
     /// \*rgb buffer should have a size of at least height \* rgb_stride.
     /// Returns false in case of memory error.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureImportRGB(
         picture: *mut WebPPicture,
         rgb: *const u8,
         rgb_stride: c_int,
     ) -> c_int;
     /// Same as [WebPPictureImportRGB], but for RGBA buffer.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureImportRGBA(
         picture: *mut WebPPicture,
         rgba: *const u8,
@@ -656,28 +656,28 @@ unsafe extern "C" {
     /// Same as [WebPPictureImportRGB], but for RGBA buffer. Imports the RGB direct from the 32-bit format
     /// input buffer ignoring the alpha channel. Avoids needing to copy the data
     /// to a temporary 24-bit RGB buffer to import the RGB only.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureImportRGBX(
         picture: *mut WebPPicture,
         rgbx: *const u8,
         rgbx_stride: c_int,
     ) -> c_int;
     /// Variants of the above [WebPPictureImportRGB], but taking BGR(A|X) input.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureImportBGR(
         picture: *mut WebPPicture,
         bgr: *const u8,
         bgr_stride: c_int,
     ) -> c_int;
     /// Variants of the above [WebPPictureImportRGB], but taking BGR(A|X) input.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureImportBGRA(
         picture: *mut WebPPicture,
         bgra: *const u8,
         bgra_stride: c_int,
     ) -> c_int;
     /// Variants of the above [WebPPictureImportRGB], but taking BGR(A|X) input.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureImportBGRX(
         picture: *mut WebPPicture,
         bgrx: *const u8,
@@ -689,13 +689,13 @@ unsafe extern "C" {
     /// non-opaque transparent values is detected, and `colorspace` will be
     /// adjusted accordingly. Note that this method is lossy.
     /// Returns false in case of error.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureARGBToYUVA(picture: *mut WebPPicture, colorspace: WebPEncCSP) -> c_int;
     /// Same as WebPPictureARGBToYUVA(), but the conversion is done using
     /// pseudo-random dithering with a strength `dithering` between
     /// 0.0 (no dithering) and 1.0 (maximum dithering). This is useful
     /// for photographic picture.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureARGBToYUVADithered(
         picture: *mut WebPPicture,
         colorspace: WebPEncCSP,
@@ -707,11 +707,11 @@ unsafe extern "C" {
     /// and sharper YUV representation.
     /// Returns false in case of error.
     #[cfg(feature = "0_6")]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureSharpARGBToYUVA(picture: *mut WebPPicture) -> c_int;
     /// kept for backward compatibility:
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureSmartARGBToYUVA(picture: *mut WebPPicture) -> c_int;
     /// Converts picture->yuv to picture->argb and sets picture->use_argb to true.
     /// The input format must be YUV_420 or YUV_420A. The conversion from YUV420 to
@@ -719,7 +719,7 @@ unsafe extern "C" {
     /// Note that the use of this colorspace is discouraged if one has access to the
     /// raw ARGB samples, since using YUV420 is comparatively lossy.
     /// Returns false in case of error.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPPictureYUVAToARGB(picture: *mut WebPPicture) -> c_int;
     /// Helper function: given a width x height plane of RGBA or YUV(A) samples
     /// clean-up or smoothen the YUV or RGB samples under fully transparent area,
@@ -743,7 +743,7 @@ unsafe extern "C" {
     /// the former for lossy encoding, and the latter for lossless encoding
     /// (when config.lossless is true). Automatic conversion from one format to
     /// another is provided but they both incur some loss.
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPEncode(config: *const WebPConfig, picture: *mut WebPPicture) -> c_int;
 }
 
@@ -752,7 +752,7 @@ unsafe extern "C" {
 /// must have succeeded before using the `config` object.
 /// Note that the default values are lossless=0 and quality=75.
 #[allow(non_snake_case)]
-#[cfg_attr(feature = "must-use", must_use)]
+#[must_use]
 #[inline]
 pub unsafe extern "C" fn WebPConfigInit(config: *mut WebPConfig) -> c_int {
     unsafe {
@@ -770,7 +770,7 @@ pub unsafe extern "C" fn WebPConfigInit(config: *mut WebPConfig) -> c_int {
 /// This function can be called as a replacement to WebPConfigInit(). Will
 /// return false in case of error.
 #[allow(non_snake_case)]
-#[cfg_attr(feature = "must-use", must_use)]
+#[must_use]
 #[inline]
 pub unsafe extern "C" fn WebPConfigPreset(
     config: *mut WebPConfig,
@@ -785,7 +785,7 @@ pub unsafe extern "C" fn WebPConfigPreset(
 /// `picture` object.
 /// Note that, by default, use_argb is false and colorspace is WEBP_YUV420.
 #[allow(non_snake_case)]
-#[cfg_attr(feature = "must-use", must_use)]
+#[must_use]
 #[inline]
 pub unsafe extern "C" fn WebPPictureInit(picture: *mut WebPPicture) -> c_int {
     unsafe { WebPPictureInitInternal(picture, WEBP_ENCODER_ABI_VERSION) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ mod mux;
 mod mux_types;
 mod types;
 
+#[cfg(not(feature = "std"))]
+compile_error!("`std` feature is currently required");
+
 #[allow(unused)]
 fn ensure_rust_1_85() {
     let _ = 0_u32.midpoint(2);

--- a/src/mux.rs
+++ b/src/mux.rs
@@ -30,7 +30,7 @@ unsafe extern "C" {
 pub struct WebPMux(c_void);
 
 #[allow(non_camel_case_types)]
-// #[cfg_attr(feature = "must-use", must_use)] // meaningless for type aliases
+// #[must_use] // meaningless for type aliases
 pub type WebPMuxError = i32;
 
 pub const WEBP_MUX_OK: WebPMuxError = 1;
@@ -108,11 +108,11 @@ pub struct WebPAnimEncoderOptions {
 unsafe extern "C" {
     pub fn WebPGetMuxVersion() -> c_int;
     #[doc(hidden)]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPNewInternal(_: c_int) -> *mut WebPMux;
     pub fn WebPMuxDelete(mux: *mut WebPMux);
     #[doc(hidden)]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPMuxCreateInternal(_: *const WebPData, _: c_int, _: c_int) -> *mut WebPMux;
     pub fn WebPMuxSetChunk(
         mux: *mut WebPMux,
@@ -176,7 +176,7 @@ unsafe extern "C" {
         _: c_int,
     ) -> *mut WebPAnimEncoder;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPAnimEncoderAdd(
         enc: *mut WebPAnimEncoder,
         frame: *mut WebPPicture,
@@ -184,7 +184,7 @@ unsafe extern "C" {
         config: *const WebPConfig,
     ) -> c_int;
     #[cfg(feature = "0_5")]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPAnimEncoderAssemble(enc: *mut WebPAnimEncoder, webp_data: *mut WebPData) -> c_int;
     #[cfg(feature = "0_5")]
     pub fn WebPAnimEncoderGetError(enc: *mut WebPAnimEncoder) -> *const c_char;
@@ -211,14 +211,14 @@ unsafe extern "C" {
 }
 
 #[allow(non_snake_case)]
-#[cfg_attr(feature = "must-use", must_use)]
+#[must_use]
 #[inline]
 pub unsafe extern "C" fn WebPMuxNew() -> *mut WebPMux {
     unsafe { WebPNewInternal(WEBP_MUX_ABI_VERSION) }
 }
 
 #[allow(non_snake_case)]
-#[cfg_attr(feature = "must-use", must_use)]
+#[must_use]
 #[inline]
 pub unsafe extern "C" fn WebPMuxCreate(
     bitstream: *const WebPData,
@@ -229,7 +229,7 @@ pub unsafe extern "C" fn WebPMuxCreate(
 
 #[cfg(feature = "0_5")]
 #[allow(non_snake_case)]
-#[cfg_attr(feature = "must-use", must_use)]
+#[must_use]
 #[inline]
 pub unsafe extern "C" fn WebPAnimEncoderOptionsInit(
     enc_options: *mut WebPAnimEncoderOptions,

--- a/src/mux_types.rs
+++ b/src/mux_types.rs
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn WebPDataClear(webp_data: *mut WebPData) {
 // Allocates necessary storage for 'dst' and copies the contents of 'src'.
 // Returns true on success.
 #[allow(non_snake_case)]
-#[cfg_attr(feature = "must-use", must_use)]
+#[must_use]
 #[inline]
 pub unsafe extern "C" fn WebPDataCopy(src: *const WebPData, dst: *mut WebPData) -> c_int {
     if src.is_null() || dst.is_null() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,7 +13,7 @@ unsafe extern "C" {
     /// must be deallocated by calling `WebPFree()`. This function is made available
     /// by the core `libwebp` library.
     #[cfg(feature = "1_1")]
-    #[cfg_attr(feature = "must-use", must_use)]
+    #[must_use]
     pub fn WebPMalloc(size: usize) -> *mut c_void;
     /// Releases memory returned by the `WebPDecode*()` functions (from `decode.h`).
     #[cfg(feature = "0_5")]


### PR DESCRIPTION
- Add `std` default feature, but lack of this feature currently leads to compile error.
- Make `1_2` default. Note that libwebp 1.2.0 is already 4 years old.
- Remove `must-use` and enable it by default.
