### PR TITLE
Delegate linkage to v0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
     - Add `std` default feature. This is currently required for the crate to be compiled.
     - Make `1_2` default. If you need to support libwebp versions older than 1.2.0, you should opt out of it using default-features = false.
     - Remove `must-use`. Now `#[must_use]` annotation is always added to the relevant definitions.
+- Compatibility note
+  - 0.2.x and 0.1.x cannot coexist in the same build, except the exact 0.2.0, which delegates to 0.1.x using semver trick. Try the exact 0.2.0 version if you see the following error:
+    > the package `libwebp-sys2` links to the native library `webp`, but it conflicts with a previous package which links to `webp` as well:
 
 ## 0.1.11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,20 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
+ "libwebp-sys2 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libwebp-sys2"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4790186411a6843ecc0a141c8948c8e623a0bb5e886834b1b6c90f3dfa85bb99"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "libwebp-sys2"
 version = "0.1.11"
 authors = ["Masaki Hara <ackie.h.gmai@gmail.com>"]
-links = "webp"
-build = "build.rs"
+# links = "webp"
+# build = "build.rs"
 edition = "2024"
 rust-version = "1.85"
 
@@ -27,19 +27,21 @@ name = "libwebp_sys"
 [dependencies]
 cfg-if = "1.0.0"
 libc = "0.2.169"
+# Delegate linkage
+libwebp-sys2-01 = { version = "0.1.10", package = "libwebp-sys2" }
 
 [features]
 default = ["std", "1_2"]
 std = []
-demux = []
-mux = []
+demux = ["libwebp-sys2-01/demux"]
+mux = ["libwebp-sys2-01/mux"]
 "0_5" = []
 "0_6" = ["0_5"]
 "1_1" = ["0_6"]
 "1_2" = ["1_1"]
 "1_4" = ["1_2"]
 "1_5" = ["1_4"]
-static = []
+static = ["libwebp-sys2-01/static"]
 extern-types = []
 __doc_cfg = ["1_5", "demux", "mux"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 #[macro_use]
 extern crate cfg_if;
+extern crate libwebp_sys2_01;
 
 pub use crate::decode::*;
 #[cfg(feature = "demux")]


### PR DESCRIPTION
This change uses the semver trick so that the upcoming 0.2.0 and 0.1.x can coexist in the same dependency graph.

The point is that it is difficult to put the same library twice in the same build. Therefore, version 0.2.0 will delegate the build to 0.1.x, while providing the header independently. Future versions will remove this workaround.